### PR TITLE
Added ipxe for Harvester v1.3.1

### DIFF
--- a/ipxe/ipxe-1.3.1
+++ b/ipxe/ipxe-1.3.1
@@ -1,0 +1,24 @@
+#!ipxe
+set version v1.3.1
+set base https://github.com/harvester/harvester/releases/download/${version}
+set harvesterreleasebase https://releases.rancher.com/harvester/${version}
+dhcp
+iflinkwait -t 5000
+goto ${ifname}
+:net0
+set address ${net0/mac}
+goto setupboot
+:net1
+set address ${net1/mac}
+goto setupboot
+:net2
+set address ${net2/mac}
+goto setupboot
+:net3
+set address ${net3/mac}
+goto setupboot
+
+:setupboot
+kernel ${base}/harvester-${version}-vmlinuz-amd64 initrd=harvester-${version}-initrd-amd64 ip=dhcp net.ifnames=1 rd.cos.disable rd.noverifyssl root=live:${harvesterreleasebase}/harvester-${version}-rootfs-amd64.squashfs harvester.install.management_interface.interfaces="hwAddr:${address}" harvester.install.management_interface.method=dhcp harvester.install.management_interface.bond_options.mode=balance-tlb harvester.install.management_interface.bond_options.miimon=100 console=ttyS1,115200 harvester.install.automatic=true boot_cmd="echo include_ping_test=yes >> /etc/conf.d/net-online" harvester.install.config_url=https://metadata.platformequinix.com/userdata
+initrd ${base}/harvester-${version}-initrd-amd64
+boot


### PR DESCRIPTION
Resolves issue #71 

I tested it; it seems to work correctly.

![image](https://github.com/rancherlabs/terraform-harvester-equinix/assets/140631879/2027971e-d62c-4232-b408-3f39876ab631)

Following is the variable.tf file I used to test ->
`variable "harvester_version" {
  default = "v1.3.1"
}

variable "node_count" {
  default = "3"
}

variable "project_name" {
  default = "Harvester Labs"
}

variable "metal_create_project" {
  type        = bool
  default     = false
  description = "Create a Metal Project if this is 'true'. Else use provided 'project_name'"
}

variable "plan" {
  default = "m3.small.x86"
}

variable "billing_cylce" {
  default = "hourly"
}

variable "metro" {
  default = "SV"
}

variable "ipxe_script" {
  **default = "https://raw.githubusercontent.com/rancherlabs/terraform-harvester-equinix/feature/ipxe-1.3.1/ipxe/ipxe-"**
}

variable "hostname_prefix" {
  default = "glovecchio-harv"
}

variable "spot_instance" {
  default     = true
  description = "Set to true to use spot instance instead of on demand. Also set you max bid price if true."
}

variable "max_bid_price" {
  default     = "0.75"
  description = "Maximum bid price for spot request."
}

variable "ssh_key" {
  default     = "<MY-SSH-PRIVATE-KEY>"
  description = "ssh key"
}

variable "num_of_vlans" {
  default     = 2
  description = "Number of VLANs to be created"
}

variable "rancher_api_url" {
  default     = ""
  description = "Rancher API endpoint to manager your Harvester cluster"
}

variable "rancher_access_key" {
  default     = ""
  description = "Rancher access key"
}

variable "rancher_secret_key" {
  default     = ""
  description = "Rancher secret key"
}

variable "rancher_insecure" {
  default     = false
  description = "Allow insecure connections to the Rancher API"
}

variable "api_key" {
  type        = string
  description = "Equinix Metal authentication token"
  default     = "<MY-EQUINIX-API-TOKEN>"
}

variable "use_cheapest_metro" {
  description = "A boolean variable to control cheapest metro selection"
  type        = bool
  default     = true
}`